### PR TITLE
RDKOSS-241: Integrate rust 1.82.0 from meta-lts-mixin

### DIFF
--- a/rdk-oss-common.xml
+++ b/rdk-oss-common.xml
@@ -28,4 +28,8 @@
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_PYTHON2"/>
   </project>
 
+  <project groups="mixin" name="meta-lts-mixins" path="meta-lts-mixins" remote="rdkcentral" revision="refs/tags/rdk-4.0.0">
+  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_MIXIN" />
+  </project>
+
 </manifest>


### PR DESCRIPTION
Reason for change: Include meta-lts-mixin to oss manifest to build rust version 1.82.0