### PR TITLE
RDKOSS-1063: OSS Release 4.14.0

### DIFF
--- a/rdk-oss-common.xml
+++ b/rdk-oss-common.xml
@@ -27,11 +27,21 @@
   <project groups="oe" name="meta-python2" path="meta-python2" remote="rdkcentral" revision="refs/tags/rdk-4.0.0">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_PYTHON2"/>
   </project>
+
   <project groups="oe" name="meta-clang" path="meta-clang" remote="rdkcentral" revision="refs/tags/rdk-4.1.0">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_CLANG"/>
   </project>
+
   <project groups="mixin" name="meta-lts-mixins" path="meta-lts-mixins" remote="rdkcentral" revision="refs/tags/rdk-4.0.0">
   <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_MIXIN" />
+  </project>
+
+  <project groups="layers" name="meta-rdk-bluetooth" path="meta-rdk-bluetooth" remote="rdkcentral" revision="develop">
+  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_RDK_BLUETOOTH"/>
+  </project>
+
+  <project groups="layers" name="meta-binder" path="meta-binder" remote="rdkcentral" revision="develop">
+  <annotation name="MANIFEST_EXPORT_PATH" value="MANIFEST_PATH_META_BINDER"/>
   </project>
 
 </manifest>


### PR DESCRIPTION
Reason for change: Add meta-rdk-bluetooth and meta-binder in the manifest